### PR TITLE
fix: add jsconfig.json, fix input issue

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -78,12 +78,13 @@ export default {
         this.mdRes = VR.renderMarkdown()
         this.renderRes = VR.render()
 
-        this.consumerSource = this.mdRes ? this.mdRes.content : ''
+        this.handleSwitch(this.currentType)
       } catch (e) {
         this.consumerSource = e.toString()
       }
     },
     handleSwitch(type) {
+      console.log(type)
       this.currentType = type
       switch (type) {
         // Raw markdown


### PR DESCRIPTION
add jsconfig.json so that you can get intellisense when you use path alias, fix bug when you input  the right codeMirror value became raw markdown result , which actually should dependent on the switch